### PR TITLE
fix: use uint64 for bit shift to support 32-bit architectures

### DIFF
--- a/mls.go
+++ b/mls.go
@@ -67,7 +67,7 @@ func readOpaqueVec(s *cryptobyte.String, out *[]byte) bool {
 }
 
 func writeOpaqueVec(b *cryptobyte.Builder, value []byte) {
-	if len(value) >= 1<<32 {
+	if uint64(len(value)) >= 1<<32 {
 		b.SetError(fmt.Errorf("mls: opaque size exceeds maximum value of uint32"))
 		return
 	}


### PR DESCRIPTION
The expression `1<<32` overflows on 32-bit int, causing compilation errors on GOARCH=386 and other 32-bit targets. Cast len(value) to uint64 before comparison to avoid constant overflow.